### PR TITLE
fix: change chip component, handle link hithub

### DIFF
--- a/src/components/article/ArticleHero.tsx
+++ b/src/components/article/ArticleHero.tsx
@@ -40,6 +40,7 @@ const ArticleHero = ({ data }: Props) => {
     createdAt,
     metaDescription,
     project_category,
+    linkGithub,
     body: {
       childMarkdownRemark: { timeToRead },
     },
@@ -47,7 +48,11 @@ const ArticleHero = ({ data }: Props) => {
 
   return (
     <div>
-      <LinkSection category={project_category[0].slug} url={url} />
+      <LinkSection
+        category={project_category[0].slug}
+        url={url}
+        githubUrl={linkGithub}
+      />
       <Box mx='auto' sx={{ marginTop: "10px" }}>
         <Typography
           component='h1'

--- a/src/components/article/LinkSection.tsx
+++ b/src/components/article/LinkSection.tsx
@@ -1,28 +1,14 @@
 import React from "react";
+import { Link as GatsbyLink } from "gatsby";
 import styled from "@emotion/styled";
-import { Stack, Box, css } from "@mui/material";
+import { Stack, Box, Chip, css } from "@mui/material";
 import GitHubIcon from "@mui/icons-material/GitHub";
 
 interface Props {
   category: string;
   url?: string;
+  githubUrl: string;
 }
-
-const CategoryChip = styled(Box)(
-  css({
-    width: ["120px", "130px"],
-    height: "20px",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: "20px",
-    border: "1px solid #E9E3FF",
-    color: "#8769FE",
-    fontSize: "12px",
-  })
-);
-
-const LinkStack = styled(Stack)(css({}));
 
 const LinkContainer = styled(Box)(
   css({
@@ -36,7 +22,7 @@ const LinkContainer = styled(Box)(
   })
 );
 
-const LinkSection = ({ category, url }: Props) => {
+const LinkSection = ({ category, url, githubUrl }: Props) => {
   const handleLabel = React.useCallback((category: string) => {
     let label;
     switch (category) {
@@ -55,21 +41,35 @@ const LinkSection = ({ category, url }: Props) => {
 
   return (
     <Stack direction='row' alignItems='center' justifyContent='space-between'>
-      <CategoryChip>{label}</CategoryChip>
+      <Chip
+        label={label}
+        variant='outlined'
+        sx={{
+          height: "20px",
+          fontSize: "12px",
+          borderRadius: "20px",
+          border: "1px solid #E9E3FF",
+          color: "#8769FE",
+        }}
+      />
 
-      <LinkStack direction='row'>
+      <Stack direction='row'>
         {url && (
           <LinkContainer>
-            <a href={url} target='_blank' rel='noopener noreferrer'>
+            {/* @ts-ignore */}
+            <GatsbyLink to={url} target='_blank'>
               Vedi
-            </a>
+            </GatsbyLink>
           </LinkContainer>
         )}
 
-        <a href={url} target='_blank' rel='noopener noreferrer'>
-          <GitHubIcon />
-        </a>
-      </LinkStack>
+        {githubUrl && (
+          /* @ts-ignore */
+          <GatsbyLink to={githubUrl} target='_blank'>
+            <GitHubIcon />
+          </GatsbyLink>
+        )}
+      </Stack>
     </Stack>
   );
 };

--- a/src/template/ProjectArticle.tsx
+++ b/src/template/ProjectArticle.tsx
@@ -97,6 +97,7 @@ export const query = graphql`
         project_category {
           slug
         }
+        linkGithub
       }
     }
   }

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -81,6 +81,7 @@ export type ProjectProps = {
   url?: string;
   metaDescription?: string;
   body: ProjectBodyProps;
+  linkGithub: string;
   project_category: [
     {
       slug: string;


### PR DESCRIPTION
## Done
- changed the old chip with MUI Chip
- add the linkGithub option to the Project Model on Contentful for each project, and set it with the corresponding link
- if the linkGithub is null the icon is not rendered