### PR TITLE
Feat: uso dei nuovi campi di slug

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -85,16 +85,11 @@ exports.createPages = async ({ graphql, actions }) => {
 
   projectArticleQuery.data.allContentfulProgetti.nodes.forEach((project) => {
     const courseSlug = project.project_category?.[0]?.slug;
-    let slug = project.titolo;
-    slug = slug
-      .replace(/\s/g, "-")
-      .replace(/[^a-zA-Z0-9-]/g, "")
-      .toLowerCase();
     const nextProjectOrder = project.ordine + 1;
     const courseId = project.corsi[0].idCorso;
-    if (project.body && courseSlug) {
+    if (courseSlug) {
       createPage({
-        path: `/progetti/${courseSlug}/${slug}/`,
+        path: `/progetti/${courseSlug}/${project.slug}/`,
         component: path.resolve(`./src/template/ProjectArticle.tsx`),
         context: {
           id: project.id,

--- a/query.js
+++ b/query.js
@@ -31,13 +31,10 @@ const allProjectArticle = `
   allContentfulProgetti {
     nodes {
       id
-      titolo
+      slug
       ordine
       project_category {
         slug
-      }
-      body {
-        body
       }
       corsi {
         idCorso

--- a/src/feature/projects/components/ArticleFooter.tsx
+++ b/src/feature/projects/components/ArticleFooter.tsx
@@ -9,7 +9,6 @@ import {
   IGatsbyImageData,
   ImageDataLike,
 } from "gatsby-plugin-image";
-import { createSlugFromTitle } from "../utils";
 import SeoLink from "../../../components/shared/SeoLink";
 
 const StyledTypography = styled(Typography)`
@@ -30,7 +29,7 @@ export const ArticleFooter = (props: Queries.SingleProjectQuery) => {
 
   const nextProjectUrl = React.useMemo(() => {
     const courseSlug = props?.project?.project_category?.[0]?.slug;
-    const slug = createSlugFromTitle(props?.nextProject?.titolo);
+    const slug = props?.nextProject?.slug;
     return `/progetti/${courseSlug}/${slug}/`;
   }, []);
 
@@ -65,7 +64,7 @@ export const ArticleFooter = (props: Queries.SingleProjectQuery) => {
                         nextProject?.copertina as unknown as ImageDataLike,
                       ) as IGatsbyImageData
                     }
-                    alt={nextProject.titolo || "Anteprima del progetto"}
+                    alt={nextProject.articleTitle || "Anteprima del progetto"}
                     style={{
                       height: "100%",
                     }}
@@ -81,7 +80,7 @@ export const ArticleFooter = (props: Queries.SingleProjectQuery) => {
               </ProjectImage>
 
               <ProjectContent
-                titolo={nextProject?.titolo as string | undefined}
+                titolo={nextProject?.articleTitle as string | undefined}
                 label={props.project?.project_category?.[0]?.slug}
                 description={nextProject?.descrizione?.descrizione}
               ></ProjectContent>

--- a/src/feature/projects/components/ArticleHero.tsx
+++ b/src/feature/projects/components/ArticleHero.tsx
@@ -12,7 +12,7 @@ export const Styledtypography = styled(Typography)(
     fontSize: "14px",
     lineHeight: "18px",
     fontWeight: "300",
-  })
+  }),
 );
 
 const StyledBox = styled(Box)(
@@ -26,14 +26,14 @@ const StyledBox = styled(Box)(
     alignItems: "center",
     overflowX: "hidden",
     borderRadius: "0px 8px 8px 0px",
-  })
+  }),
 );
 
 export const ArticleHero = (
-  props: Omit<Queries.SingleProjectQuery["project"], "id">
+  props: Omit<Queries.SingleProjectQuery["project"], "id">,
 ) => {
   const {
-    titolo,
+    articleTitle,
     url,
     createdAt,
     metaDescription,
@@ -58,7 +58,7 @@ export const ArticleHero = (
             lineHeight: { xs: "44px", lg: "56px" },
           }}
         >
-          {titolo}
+          {articleTitle}
         </Typography>
       </Box>
 

--- a/src/feature/projects/components/LatestProject.tsx
+++ b/src/feature/projects/components/LatestProject.tsx
@@ -82,7 +82,7 @@ export const LatestProject = (
             lineHeight={{ xs: "39px", lg: "54px" }}
             fontWeight={600}
           >
-            {latestProject?.titolo}
+            {latestProject?.articleTitle}
           </Typography>
           <Box mt={{ xs: "6px", lg: "8px" }}>
             <Typography
@@ -120,9 +120,7 @@ export const LatestProject = (
 
         <SeoLink
           isExternal={false}
-          link={`/progetti/${
-            latestProject?.project_category?.[0]?.slug
-          }/${createSlugFromTitle(latestProject?.titolo)}/`}
+          link={`/progetti/${latestProject?.project_category?.[0]?.slug}/${latestProject?.slug}/`}
         >
           <RoundedButton
             size='small'
@@ -150,7 +148,10 @@ export const LatestProject = (
             overflow: "hidden",
           }}
         >
-          <GatsbyImage image={image} alt={latestProject?.titolo as string} />
+          <GatsbyImage
+            image={image}
+            alt={latestProject?.articleTitle as string}
+          />
         </Box>
       ) : null}
     </StyledBox>

--- a/src/feature/projects/components/LinkSection.tsx
+++ b/src/feature/projects/components/LinkSection.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link as GatsbyLink } from "gatsby";
 import styled from "@emotion/styled";
 import { Stack, Box, Chip, css } from "@mui/material";
 import GitHubIcon from "@mui/icons-material/GitHub";
@@ -21,7 +20,7 @@ const LinkContainer = styled(Box)(
     fontWeight: "300",
     color: "#E7A7FF",
     marginRight: "18px",
-  })
+  }),
 );
 
 export const LinkSection = ({ category, url, githubUrl }: Props) => {

--- a/src/feature/projects/components/ProjectSection.tsx
+++ b/src/feature/projects/components/ProjectSection.tsx
@@ -8,7 +8,6 @@ import {
 import React from "react";
 import SeoLink from "../../../components/shared/SeoLink";
 import { ProjectSectionProps } from "../types";
-import { createSlugFromTitle } from "../utils";
 import { ProjectCard } from "./ProjectCard";
 import { ProjectContent } from "./ProjectContent";
 import { ProjectImage } from "./ProjectImage";
@@ -30,9 +29,7 @@ export const ProjectSection = ({
           <Box key={"progetto" + index} className='row-container'>
             <SeoLink
               isExternal={false}
-              link={`/progetti/${
-                post?.project_category?.[0]?.slug
-              }/${createSlugFromTitle(post?.titolo)}/`}
+              link={`/progetti/${post?.project_category?.[0]?.slug}/${post?.slug}/`}
               style={{
                 display: "flex",
                 width: "fit-content",
@@ -55,11 +52,11 @@ export const ProjectSection = ({
                           post.copertina?.gatsbyImageData as ImageDataLike,
                         ) as IGatsbyImageData
                       }
-                      alt={post.titolo as string}
+                      alt={post.articleTitle as string}
                     />
                   </ProjectImage>
                   <ProjectContent
-                    titolo={post.titolo}
+                    titolo={post.articleTitle}
                     description={post.descrizione?.descrizione}
                     label={post?.project_category?.[0]?.title}
                   />

--- a/src/feature/projects/components/Projects.tsx
+++ b/src/feature/projects/components/Projects.tsx
@@ -92,7 +92,7 @@ export const Projects = ({ data }: { data: Queries.ContentfulProgetti[] }) => {
                     </ProjectImage>
 
                     <ProjectContent
-                      titolo={progetto?.articleTitle}
+                      titolo={progetto?.titolo}
                       label={progetto?.project_category?.[0]?.title}
                       description={cleanStringFromHtlmTags(
                         progetto?.descrizione?.childMarkdownRemark?.html,

--- a/src/feature/projects/components/Projects.tsx
+++ b/src/feature/projects/components/Projects.tsx
@@ -12,7 +12,6 @@ import {
   IGatsbyImageData,
   ImageDataLike,
 } from "gatsby-plugin-image";
-import { createSlugFromTitle } from "../utils";
 
 const CustomStack = styled(Box)`
   height: 100%;
@@ -43,7 +42,7 @@ export const Projects = ({ data }: { data: Queries.ContentfulProgetti[] }) => {
   const rows = React.useMemo(() => rowalizer(data, 2), []);
   return (
     <CustomStack>
-      {rows.map((row, index) => {
+      {rows?.map((row, index) => {
         return (
           <Box
             key={"progetto" + index}
@@ -55,9 +54,7 @@ export const Projects = ({ data }: { data: Queries.ContentfulProgetti[] }) => {
             {row.map((progetto) => (
               <SeoLink
                 isExternal={false}
-                link={`/progetti/${
-                  progetto?.project_category?.[0]?.slug
-                }/${createSlugFromTitle(progetto?.titolo)}/`}
+                link={`/progetti/${progetto?.project_category?.[0]?.slug}/${progetto?.slug}/`}
                 style={{
                   display: "flex",
                   width: "fit-content",
@@ -77,7 +74,9 @@ export const Projects = ({ data }: { data: Queries.ContentfulProgetti[] }) => {
                               progetto?.copertina as unknown as ImageDataLike,
                             ) as IGatsbyImageData
                           }
-                          alt={progetto.titolo || "Anteprima del progetto"}
+                          alt={
+                            progetto.articleTitle || "Anteprima del progetto"
+                          }
                           style={{
                             height: "100%",
                           }}
@@ -93,7 +92,7 @@ export const Projects = ({ data }: { data: Queries.ContentfulProgetti[] }) => {
                     </ProjectImage>
 
                     <ProjectContent
-                      titolo={progetto?.titolo}
+                      titolo={progetto?.articleTitle}
                       label={progetto?.project_category?.[0]?.title}
                       description={cleanStringFromHtlmTags(
                         progetto?.descrizione?.childMarkdownRemark?.html,

--- a/src/feature/projects/types/index.ts
+++ b/src/feature/projects/types/index.ts
@@ -1,4 +1,9 @@
 export type ProjectSectionProps = Pick<
   Queries.ContentfulProgetti,
-  "project_category" | "titolo" | "copertina" | "descrizione"
+  | "project_category"
+  | "titolo"
+  | "copertina"
+  | "descrizione"
+  | "articleTitle"
+  | "slug"
 >[];

--- a/src/template/ProjectArticle.tsx
+++ b/src/template/ProjectArticle.tsx
@@ -14,7 +14,6 @@ import { createRowText } from "../utils/helpers";
 import ArticleSchema from "../components/SEO/components/ArticleSchema";
 import LinkHandler from "../components/SEO/components/LinkHandler";
 import { BottomBanner } from "../components/layout";
-import { createSlugFromTitle } from "../feature/projects/utils";
 import SeoLink from "../components/shared/SeoLink";
 
 const FlexContainer = styled(Box)`
@@ -41,12 +40,15 @@ const ProjectArticle = ({ data }: PageProps<Queries.SingleProjectQuery>) => {
 
   const breadcrumbs = React.useMemo(() => {
     const courseSlug = queryData?.project_category?.[0]?.slug;
-    const slug = createSlugFromTitle(queryData?.titolo);
+    const slug = queryData?.slug;
     return [
       { text: "Home", link: "/" },
       { text: "Progetti", link: "/progetti/" },
       { text: `Progetti ${courseSlug}`, link: `/progetti/${courseSlug}/` },
-      { text: queryData?.titolo, link: `/progetti/${courseSlug}/${slug}/` },
+      {
+        text: queryData?.articleTitle,
+        link: `/progetti/${courseSlug}/${slug}/`,
+      },
     ];
   }, [queryData]);
 
@@ -58,7 +60,7 @@ const ProjectArticle = ({ data }: PageProps<Queries.SingleProjectQuery>) => {
   return (
     <Layout>
       <MetaDecorator
-        metaTitle={createRowText(queryData?.titolo as any)}
+        metaTitle={createRowText(queryData?.articleTitle as any)}
         metaDescription={queryData?.metaDescription as any}
         image={
           queryData && (("https:" + queryData?.copertina?.file?.url) as any)
@@ -66,14 +68,14 @@ const ProjectArticle = ({ data }: PageProps<Queries.SingleProjectQuery>) => {
       ></MetaDecorator>
       <LinkHandler />
       <ArticleSchema
-        title={createRowText(queryData?.titolo as any)}
+        title={createRowText(queryData?.articleTitle as any)}
         description={queryData?.descrizione?.descrizione as any}
         authorName='hpv4learning'
         breadcrumbs={breadcrumbs as any}
         image={
           queryData && (("https:" + queryData?.copertina?.file?.url) as any)
         }
-        imageAltText={createRowText(queryData?.titolo as any)}
+        imageAltText={createRowText(queryData?.articleTitle as any)}
         modifiedDate={queryData?.updatedAt as any}
         publishDate={queryData?.createdAt as any}
       />
@@ -133,6 +135,8 @@ export const query = graphql`
     project: contentfulProgetti(id: { eq: $id }) {
       id
       titolo
+      articleTitle
+      slug
       metaDescription
       ordine
       url
@@ -173,7 +177,8 @@ export const query = graphql`
       ordine: { eq: $nextProjectOrder }
       corsi: { elemMatch: { idCorso: { eq: $courseId } } }
     ) {
-      titolo
+      articleTitle
+      slug
       descrizione {
         descrizione
       }

--- a/src/template/ProjectsCategory.tsx
+++ b/src/template/ProjectsCategory.tsx
@@ -111,6 +111,8 @@ export const query = graphql`
     ) {
       nodes {
         titolo
+        slug
+        articleTitle
         copertina {
           gatsbyImageData
         }

--- a/src/template/ProjectsHome.tsx
+++ b/src/template/ProjectsHome.tsx
@@ -76,6 +76,8 @@ export const query = graphql`
         fieldValue
         nodes {
           titolo
+          articleTitle
+          slug
           descrizione {
             descrizione
           }
@@ -96,6 +98,8 @@ export const query = graphql`
       edges {
         node {
           titolo
+          articleTitle
+          slug
           descrizione {
             descrizione
           }

--- a/src/template/SingleCoursePage.tsx
+++ b/src/template/SingleCoursePage.tsx
@@ -532,6 +532,8 @@ export const query = graphql`
       }
       progetti {
         titolo
+        slug
+        articleTitle
         url
         ordine
         copertina {


### PR DESCRIPTION
## Done 

Contentful ora supporta `slug` e `articleTitle` per i progetti. 
- Rimozione del vecchio pattern di creazione degli slug
- Improve delle query
- Rimozione slug e titoli errati