### PR TITLE
feat: create server-side route 'consulenze'

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -21,7 +21,7 @@ exports.createPages = async ({ graphql, actions }) => {
       context: {
         slug: node.slug,
         categorySlug: node.category.filter(
-          (category) => category.slug !== "gratuiti",
+          (category) => category.slug !== "gratuiti"
         )[0].slug,
       },
     });
@@ -51,12 +51,17 @@ exports.createPages = async ({ graphql, actions }) => {
     component: path.resolve("./src/template/ProjectsHome.tsx"),
   });
 
+  createPage({
+    path: "/consulenze/",
+    component: path.resolve("./src/template/Consulenze.tsx"),
+  });
+
   categoryProjectQuery.data.allContentfulProjectCategory.nodes.forEach(
     (category) => {
       if (!isEmpty(category.categoryProjects)) {
         const numOfElement = 9;
         const pages = Math.ceil(
-          category.categoryProjects.length / numOfElement,
+          category.categoryProjects.length / numOfElement
         );
 
         Array.from({ length: pages }, (_, index) => {
@@ -82,13 +87,13 @@ exports.createPages = async ({ graphql, actions }) => {
           });
         });
       }
-    },
+    }
   );
 
   projectArticleQuery.data.allContentfulProgetti.group.forEach((category) => {
     const slug = category.fieldValue;
     const maxProjectsOrders = Math.max(
-      ...category.nodes.map((project) => project.ordine),
+      ...category.nodes.map((project) => project.ordine)
     );
     category.nodes.forEach((project) => {
       const nextProjectOrder =

--- a/src/template/Consulenze.tsx
+++ b/src/template/Consulenze.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import Layout from "../components/shared/layout";
+import { Button } from "@mui/material";
+
+const Consulenze = () => {
+  return (
+    <>
+      <Layout>
+        <Button>ciao</Button>
+      </Layout>
+    </>
+  );
+};
+
+export default Consulenze;


### PR DESCRIPTION
## Done 
Creato la route per le consulenze lato server

## To Do 
Implementare le routes client-only

## Domanda
Ho chiaro come settarle, ma non ho chiaro il motivo per cui ci servono. 
L'obiettivo è quello di mettere un router nella pagine delle consulenze, e tramite la modifica del path andare a scorrere tra le varie schermate del modal?
In questo modo vado a creare un componente per ogni schermata, e premendo sul pulsante avanti (che diventa abilitato solo se tutte le informazioni sono inserite correttamente) vado a modificare il path per navigare alla schermata successiva. Giusto? Non vorrei aver capito cazzi per mazzi
