### PR TITLE
Add function to book calendar

### DIFF
--- a/src/api/calendar/book-appointment.ts
+++ b/src/api/calendar/book-appointment.ts
@@ -34,6 +34,8 @@ const createCalendarDescription = (props: ReqProps["body"]) => {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const handler = async (req: ReqProps, res: any) => {
+  if (req.method === "PUT" && process.env.NODE_ENV === "production")
+    throw new Error("Use PUT Method");
   if (!req.query) throw new Error("Mancano i query params nell'URL");
   if (!req.body && process.env.NODE_ENV === "production")
     throw new Error("Body mancante");

--- a/src/api/calendar/book-appointment.ts
+++ b/src/api/calendar/book-appointment.ts
@@ -1,0 +1,87 @@
+import { calendarId, calendar_key, testingMail } from "../../server/constants";
+import { calendar, auth } from "../../server/utils/api";
+import { HttpMethod } from "../../server/types";
+import { isValidMail } from "../../server/utils";
+
+type ReqProps = {
+  method: HttpMethod;
+  query: {
+    [x: string]: string;
+  };
+  body: {
+    email: string;
+    nome?: string;
+    cognome?: string;
+    professione?: string;
+    description?: string;
+  };
+};
+
+const createCalendarDescription = (props: ReqProps["body"]) => {
+  let calendarDescription: string | undefined;
+  for (const key in props) {
+    if (Object.prototype.hasOwnProperty.call(props, key)) {
+      const element = props[key as keyof ReqProps["body"]];
+
+      if (element) {
+        if (key === "email" || key === "description") continue;
+        calendarDescription += ` ${element}`;
+      }
+    }
+  }
+  return calendarDescription;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const handler = async (req: ReqProps, res: any) => {
+  if (!req.query) throw new Error("Mancano i query params nell'URL");
+  if (!req.body && process.env.NODE_ENV === "production")
+    throw new Error("Body mancante");
+  const description = createCalendarDescription(req.body);
+  const { email } = req.body;
+  const { eventId } = req.query;
+  const userMail = process.env.NODE_ENV === "production" ? email : testingMail;
+  if (!isValidMail(userMail)) throw new Error("Email non valida");
+  try {
+    const { data } = await calendar.events.get({
+      calendarId,
+      eventId,
+      auth,
+    });
+
+    try {
+      const { data: responseData } = await calendar.events.update({
+        calendarId,
+        sendUpdates: "all",
+        eventId,
+        auth,
+        key: calendar_key,
+        requestBody: {
+          attendees: [
+            {
+              email: userMail,
+              responseStatus: "accepted",
+              displayName: req.body?.nome,
+            },
+          ],
+          description: description || "#booked",
+          summary: `Consulenza con ${userMail}`,
+
+          start: data.start,
+          end: data.end,
+        },
+      });
+
+      const { start, hangoutLink } = responseData;
+      res.status(200).json({ start, hangoutLink });
+    } catch (error) {
+      res.status(400).json({ error });
+    }
+  } catch (error) {
+    res
+      .status(500)
+      .json({ message: "C'è stato un errore, riprova più tardi", error });
+  }
+};
+
+export default handler;

--- a/src/api/calendar/delete-appointment.ts
+++ b/src/api/calendar/delete-appointment.ts
@@ -1,0 +1,55 @@
+import { isEmpty } from "lodash";
+import { calendarId, calendar_key } from "../../server/constants";
+import { HttpMethod } from "../../server/types";
+import { calendar, auth } from "../../server/utils/api";
+
+type ReqProps = {
+  method: HttpMethod;
+  query: {
+    [x: string]: string;
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const handler = async (req: ReqProps, res: any) => {
+  if (req.method !== "DELETE") throw new Error("Use DELETE method");
+  if (isEmpty(req.query)) throw new Error("Pass eventId as query param");
+
+  const { eventId } = req.query;
+
+  try {
+    const { data } = await calendar.events.get({
+      calendarId,
+      eventId,
+      auth,
+    });
+
+    try {
+      await calendar.events.update({
+        calendarId,
+        eventId,
+        auth,
+        key: calendar_key,
+        requestBody: {
+          summary: "Consulenza Libera",
+          description: "#consulenze",
+          attendees: [],
+          start: data.start,
+          end: data.end,
+        },
+      });
+      res.status(200).json(true);
+    } catch (error) {
+      res.status(500).json({
+        message: "Errore durante l'eliminazione dell'appuntamento. Riprova",
+        error,
+      });
+    }
+  } catch (error) {
+    res
+      .status(404)
+      .json({ message: `Non esistono calendar con id: ${eventId}`, error });
+  }
+};
+
+export default handler;

--- a/src/api/calendar/get-all-calendars.ts
+++ b/src/api/calendar/get-all-calendars.ts
@@ -4,15 +4,15 @@ import { auth, calendar } from "../../server/utils/api";
 
 type ReqProps = {
   method: HttpMethod;
-  body: {
-    email: string;
+  query?: {
+    startDate: string;
   };
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const handler = async (req: ReqProps, res: any) => {
   if (req.method !== "GET") throw new Error("Use GET Method");
-  getAllAvialableConsulenze()
+  getAllAvialableConsulenze(req?.query?.startDate)
     .then((response) => res.status(200).json(response.data.items))
     .catch((error) =>
       res.status(500).json({
@@ -21,13 +21,15 @@ const handler = async (req: ReqProps, res: any) => {
     );
 };
 
-async function getAllAvialableConsulenze() {
+async function getAllAvialableConsulenze(date?: string) {
+  const startDate = date ? Date.parse(date) : Date.now();
+
   return calendar.events.list({
     calendarId: calendarId,
     q: "#consulenze",
     auth,
-    timeMin: new Date(Date.now()).toISOString(),
-    timeMax: new Date(Date.now() + 1000 * 60 * 60 * 24 * 21).toISOString(),
+    timeMin: new Date(startDate).toISOString(),
+    timeMax: new Date(startDate + 1000 * 60 * 60 * 24 * 21).toISOString(),
   });
 }
 

--- a/src/api/calendar/get-appointment-by-mail.ts
+++ b/src/api/calendar/get-appointment-by-mail.ts
@@ -1,5 +1,5 @@
 import { calendar, auth } from "../../server/utils/api";
-import { calendarId } from "../../server/constants";
+import { calendarId, testingMail } from "../../server/constants";
 import { isEmpty } from "lodash";
 import { isValidMail } from "../../server/utils";
 import { HttpMethod } from "../../server/types";
@@ -20,7 +20,10 @@ const handler = (req: ReqProps, res: any) => {
     if (process.env.NODE_ENV === "production") throw new Error("Invalid Mail");
   }
 
-  userHasApointment(req?.body?.mail || "gianni@gmail.com")
+  const userMail =
+    process.env.NODE_ENV === "production" ? req.body.mail : testingMail;
+
+  userHasApointment(userMail)
     .then((response) => res.status(200).json(response))
     .catch((error) =>
       res

--- a/src/api/calendar/get-appointment-by-mail.ts
+++ b/src/api/calendar/get-appointment-by-mail.ts
@@ -6,22 +6,22 @@ import { HttpMethod } from "../../server/types";
 
 type ReqProps = {
   method: HttpMethod;
-  body: {
-    mail: string;
+  query: {
+    email: string;
   };
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const handler = (req: ReqProps, res: any) => {
-  if (req.method !== "POST" && process.env.NODE_ENV === "production")
-    throw new Error("Use POST Method");
-
-  if (!isValidMail(req?.body?.mail)) {
+  if (req.method !== "GET" && process.env.NODE_ENV === "production")
+    throw new Error("Use GET Method");
+  const userMail =
+    process.env.NODE_ENV === "production" && req.query.email
+      ? req.query.email
+      : testingMail;
+  if (!isValidMail(userMail)) {
     if (process.env.NODE_ENV === "production") throw new Error("Invalid Mail");
   }
-
-  const userMail =
-    process.env.NODE_ENV === "production" ? req.body.mail : testingMail;
 
   userHasApointment(userMail)
     .then((response) => res.status(200).json(response))

--- a/src/api/calendar/get-appointment-by-mail.ts
+++ b/src/api/calendar/get-appointment-by-mail.ts
@@ -40,7 +40,13 @@ async function userHasApointment(email: string) {
     timeMin: new Date(Date.now()).toISOString(),
   });
 
-  return isEmpty(appointemnt.data.items) ? [] : appointemnt.data.items;
+  return isEmpty(appointemnt.data.items)
+    ? []
+    : appointemnt.data.items?.filter((item) => ({
+        eventId: item.id,
+        start: item.start,
+        end: item.end,
+      }));
 }
 
 export default handler;

--- a/src/server/constants/index.ts
+++ b/src/server/constants/index.ts
@@ -3,3 +3,5 @@ export const mailValidationRegex = new RegExp(
   /^(([^<>()[\].,;:\s@"]+(\.[^<>()[\].,;:\s@"]+)*)|(".+"))@(([^<>()[\].,;:\s@"]+\.)+[^<>()[\].,;:\s@"]{2,})$/i,
 );
 export const calendarId = process.env.GATSBY_GOOGLE_CALENDAR_ID;
+export const calendar_key = process.env.GATSBY_GOOGLE_CALENDAR_API_KEY;
+export const testingMail = "omar.hpvfilm@gmail.com";

--- a/src/server/utils/api.ts
+++ b/src/server/utils/api.ts
@@ -3,7 +3,10 @@ import { google, calendar_v3 } from "googleapis";
 const CREDENTIALS = JSON.parse(
   process.env.GATSBY_GOOGLE_CALENDAR_CREDENTIALS as string,
 );
-const SCOPES = "https://www.googleapis.com/auth/calendar";
+const SCOPES = [
+  "https://www.googleapis.com/auth/calendar",
+  "https://www.googleapis.com/auth/calendar.events",
+];
 export const auth = new google.auth.JWT(
   CREDENTIALS.client_email,
   undefined,
@@ -11,4 +14,7 @@ export const auth = new google.auth.JWT(
   SCOPES,
 );
 
-export const calendar: calendar_v3.Calendar = google.calendar("v3");
+export const calendar: calendar_v3.Calendar = google.calendar({
+  version: "v3",
+  auth,
+});


### PR DESCRIPTION
## Done 

Aggiunte serverless functions per prenotare appuntamento e per cancellare appuntamento.
Recap funzioni: 
- `/api/calendar/get-all-calendars`--> GET può avere un query params `startDate` per passare la data in formato yyyy-MM-dd  `api/calendar/get-all-calendars?startDate=2022-09-01`
- `/api/calendar/get-appointment-by-mail?email<email>` --> GET ritorna id e data di inizio e fine del calendario se presente
- `/api/calendar/book-appointment`--> PUT prenota appuntamento (ancora da testare, per dispetti di Google Calendar ma dovrebbe funzionare ) modifica un appuntamento prenotando la call ( anche essa da testare )
- `/api/calendar/delete-appointment?eventId=<eventId>` --> DELETE libera una casella per le consulenze.