### PR TITLE
feat: add custom events dispatching

### DIFF
--- a/src/components/CourseInfo.tsx
+++ b/src/components/CourseInfo.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { CourseInfoProps, ResponsiveInfoProps } from "../types/course";
 import { createStarReview } from "../utils/general";
 import { convertToHHMMSS, dateFormatter } from "../utils/helpers";
+import { triggerGACustomEvent } from "../utils/tracking";
 import SeoLink from "./shared/SeoLink";
 
 const CourseInfo = ({
@@ -106,6 +107,14 @@ const CourseInfo = ({
                 borderRadius: "100px",
                 width: "100%",
               }}
+              onClick={
+                tipologia.toLowerCase() === "free"
+                  ? undefined
+                  : triggerGACustomEvent(
+                      { event: "click_to_udemy" },
+                      { hasLocation: true },
+                    )
+              }
             >
               {tipologia.toLowerCase() === "free"
                 ? "Vedi su Youtube"
@@ -190,6 +199,14 @@ const ResponsiveInfoBox = ({
                 borderRadius: "100px",
                 width: "100%",
               }}
+              onClick={
+                tipologia.toLowerCase() === "free"
+                  ? undefined
+                  : triggerGACustomEvent(
+                      { event: "click_to_udemy" },
+                      { hasLocation: true },
+                    )
+              }
             >
               {tipologia.toLowerCase() === "free"
                 ? "Vedi su Youtube"

--- a/src/components/banner/ComunityBanner.tsx
+++ b/src/components/banner/ComunityBanner.tsx
@@ -9,6 +9,7 @@ import {
 } from "@mui/material";
 import styled from "@emotion/styled";
 import ArrowRightAltSharpIcon from "@mui/icons-material/ArrowRightAltSharp";
+import { triggerGACustomEvent } from "../../utils/tracking";
 
 const CustomStack = styled.div`
   & > *:not(:last-of-type) {
@@ -161,6 +162,11 @@ const DiscordBanner = () => {
                     <Button
                       variant='contained'
                       color='primary'
+                      onClick={
+                        type === "youtube"
+                          ? undefined
+                          : triggerGACustomEvent({ event: "join_discord" })
+                      }
                       endIcon={
                         <ArrowRightAltSharpIcon
                           sx={{

--- a/src/components/banner/CourseBanner.tsx
+++ b/src/components/banner/CourseBanner.tsx
@@ -10,6 +10,7 @@ import {
 import { dateFormatter, isExpired } from "../../utils/helpers";
 import SeoLink from "../shared/SeoLink";
 import dayjs from "dayjs";
+import { triggerGACustomEvent } from "../../utils/tracking";
 
 const StyledBox = styled(Box)`
   border: 1px solid;
@@ -85,7 +86,7 @@ const CourseBanner = ({ title, date, prezzo, link, img }: Props) => {
               >
                 <Typography fontWeight={300} fontSize='10px'>
                   {`Scade il: ${dateFormatter(
-                    dayjs(date).add(30, "day").toString()
+                    dayjs(date).add(30, "day").toString(),
                   )}`}
                 </Typography>
               </Box>
@@ -126,6 +127,10 @@ const CourseBanner = ({ title, date, prezzo, link, img }: Props) => {
                       lg: "12px",
                     },
                   }}
+                  onClick={triggerGACustomEvent(
+                    { event: "click_to_udemy" },
+                    { hasLocation: true },
+                  )}
                   disabled={isExpired(date)}
                 >
                   {isExpired(date) ? "Esaurito" : `Solo 12.99€`}

--- a/src/components/coupon/CourseCoupon.tsx
+++ b/src/components/coupon/CourseCoupon.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { Button, Stack, Typography } from "@mui/material";
 import { Box } from "@mui/system";
 import React from "react";
+import { triggerGACustomEvent } from "../../utils/tracking";
 import SeoLink from "../shared/SeoLink";
 
 const StyledBox = styled(Box)`
@@ -144,7 +145,7 @@ const CourseCoupon = ({
                 }}
               >
                 {`-${Math.ceil(100 - (12.99 * 100) / (prezzo / 100)).toFixed(
-                  0
+                  0,
                 )}%`}
               </Typography>
             </Box>
@@ -175,6 +176,10 @@ const CourseCoupon = ({
                     borderRadius: "100px",
                     width: "100%",
                   }}
+                  onClick={triggerGACustomEvent(
+                    { event: "clic_to_udemy" },
+                    { hasLocation: true },
+                  )}
                 >
                   {isDisabled ? "Esaurito" : "Riscatta Coupon"}
                 </Button>

--- a/src/feature/projects/components/ProjectBanner.tsx
+++ b/src/feature/projects/components/ProjectBanner.tsx
@@ -6,6 +6,7 @@ import DoDisturbOnIcon from "@mui/icons-material/DoDisturbOn";
 import { useLayoutContext } from "../../../context/layout";
 import SeoLink from "../../../components/shared/SeoLink";
 import { createRowText } from "../../../utils/helpers";
+import { triggerGACustomEvent } from "../../../utils/tracking";
 
 interface Props {
   courseTitle?: string | null;
@@ -140,6 +141,10 @@ export const ProjectBanner = ({ courseTitle, prezzo, couponLink }: Props) => {
                   <Button
                     color='primary'
                     variant='contained'
+                    onClick={triggerGACustomEvent(
+                      { event: "click_to_udemy" },
+                      { hasLocation: true },
+                    )}
                     sx={{
                       width: "100%",
                       maxWidth: { xs: "105px", lg: "unset" },

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare interface Window {
+  gtag: (...args: any[]) => void;
+  dataLayer: Record<string, any>[];
+}

--- a/src/pages/join-us.tsx
+++ b/src/pages/join-us.tsx
@@ -9,6 +9,7 @@ import { jobs } from "../asset/jobsdata";
 import MetaDecorator from "../components/SEO/components/MetaDecorator";
 import LinkHandler from "../components/SEO/components/LinkHandler";
 import WebPageSchema from "../components/SEO/components/WebPageSchema";
+import { triggerGACustomEvent } from "../utils/tracking";
 
 const CustomStack = styled(Box)`
   .desktop-image {
@@ -123,6 +124,7 @@ const JoinUs = () => {
                   >
                     <SeoLink
                       isExternal
+                      onClick={triggerGACustomEvent({ event: "join_discord" })}
                       link={"https://discord.gg/pNhjB78F"}
                       rel='noopener'
                       target='_blank'

--- a/src/utils/tracking.ts
+++ b/src/utils/tracking.ts
@@ -1,0 +1,12 @@
+const isBrowser = typeof window !== "undefined";
+
+export const triggerGACustomEvent: (
+  param: Record<string, string>,
+  options?: { hasLocation?: boolean },
+) => () => void = (params, options) => () => {
+  if (!isBrowser) return;
+  const { href } = window.location;
+  const event = options?.hasLocation ? { ...params, from: href } : params;
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push(event);
+};


### PR DESCRIPTION
## Done

Dispatch di eventi custom per tracciare:
- utenti che vanno dalla landing su Udemy: `click_to_udemy`
- utenti che si uniscono a discord: `join_discord`.

Closes #238 